### PR TITLE
fix installation on node 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/magne4000/net-browserify",
   "dependencies": {
     "body-parser": "^1.16.0",
-    "bufferutil": "^2.0.0",
-    "ws": "^2.0.2"
+    "bufferutil": "^3.0.0",
+    "ws": "^3.0.0"
   }
 }


### PR DESCRIPTION
The most minimal bump on bufferutil is from 2.x to 3.x

We also take this opportunity to listen to `npm audit` and bump `ws`